### PR TITLE
032 Print has endDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ have done each day.
 
 ## Supported versions
 
-- v0.3.1
+- v0.3.2
 
 ## Installation
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -72,7 +72,7 @@ func init() {
 		&endDateString,
 		"endDate",
 		"",
-		"Date till which to find worklogs. Only functions in conjunction with startDate.")
+		"Date till which to find worklogs. Only functions in conjunction with startDate")
 	printCmd.Flags().BoolVarP(
 		&today,
 		"today",

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -72,7 +72,7 @@ func init() {
 		&endDateString,
 		"endDate",
 		"",
-		"Date till which to find worklogs")
+		"Date till which to find worklogs. Only functions in conjunction with startDate.")
 	printCmd.Flags().BoolVarP(
 		&today,
 		"today",

--- a/helpers/version.go
+++ b/helpers/version.go
@@ -2,5 +2,5 @@ package helpers
 
 const (
 	// Version keep track of the version of the application
-	Version string = "0.3.1"
+	Version string = "0.3.2"
 )

--- a/repository/repositories.go
+++ b/repository/repositories.go
@@ -12,5 +12,5 @@ type WorklogRepository interface {
 	Configure(cfg *model.Config) error
 	Save(wl *model.Work) error
 
-	GetAllSinceDate(startDate time.Time) ([]*model.Work, error)
+	GetAllBetweenDates(startDate, endDate time.Time) ([]*model.Work, error)
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -106,7 +106,7 @@ func createFile(fileName string) (*os.File, error) {
 	return file, nil
 }
 
-func (*yamlFileRepo) GetAllSinceDate(startDate time.Time) ([]*model.Work, error) {
+func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time) ([]*model.Work, error) {
 	fmt.Println("Retrieving files...")
 
 	var worklogs []*model.Work

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -112,7 +112,7 @@ func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time) ([]*model.
 	var worklogs []*model.Work
 	var errors []string
 
-	fileNames, err := getAllFileNamesFrom(startDate)
+	fileNames, err := getAllFileNamesBetweenDates(startDate, endDate)
 	if err != nil {
 		return worklogs, err
 	}
@@ -132,7 +132,7 @@ func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time) ([]*model.
 	return worklogs, nil
 }
 
-func getAllFileNamesFrom(startDate time.Time) ([]string, error) {
+func getAllFileNamesBetweenDates(startDate, endDate time.Time) ([]string, error) {
 	var files []string
 
 	err := filepath.Walk(getWorklogDir(), func(fullPath string, info os.FileInfo, err error) error {
@@ -148,7 +148,7 @@ func getAllFileNamesFrom(startDate time.Time) ([]string, error) {
 			return err
 		}
 
-		if filesDate.After(startDate) {
+		if filesDate.After(startDate) && filesDate.Before(endDate) {
 			files = append(files, fullPath)
 		}
 		return nil

--- a/service/services.go
+++ b/service/services.go
@@ -13,7 +13,7 @@ import (
 type WorklogService interface {
 	Congfigure(cfg *model.Config) error
 	CreateWorklog(wl *model.Work) (int, error)
-	GetWorklogsSince(date time.Time) ([]*model.Work, int, error)
+	GetWorklogsBetween(start, end time.Time) ([]*model.Work, int, error)
 }
 
 type service struct{}
@@ -39,8 +39,8 @@ func (*service) CreateWorklog(wl *model.Work) (int, error) {
 	return http.StatusCreated, nil
 }
 
-func (*service) GetWorklogsSince(date time.Time) ([]*model.Work, int, error) {
-	worklogs, err := repo.GetAllSinceDate(date)
+func (*service) GetWorklogsBetween(start, end time.Time) ([]*model.Work, int, error) {
+	worklogs, err := repo.GetAllBetweenDates(start, end)
 	if err != nil {
 		return worklogs, http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
Allows you to filter worklogs based on when they are for.

You can now say "Give me all worklogs on a specific date" via
`worklog print --startDate "2000-01-01" --endDate "2000-01-01"`.

The `--today` and `--thisWeek` functions of print also only specify a limited time window as well now.
