### PR TITLE
022 Output format

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -14,6 +14,7 @@ const defaultDuration = 15
 
 var providedAuthor string
 var providedDuration int
+var providedFormat string
 
 // configureCmd represents the create command
 var configureCmd = &cobra.Command{
@@ -37,7 +38,9 @@ var defaultsCmd = &cobra.Command{
 	Long: `Default variables to be used with the
 worklog application.`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if providedAuthor == "" && providedDuration < 0 {
+		if providedAuthor == "" &&
+			providedFormat == "" &&
+			providedDuration < 0 {
 			return errors.New("defaults requires at least one argument")
 		}
 		if providedDuration < 0 {
@@ -64,10 +67,15 @@ func init() {
 		"duration",
 		-1,
 		"Default duration that work takes")
+	defaultsCmd.Flags().StringVar(
+		&providedFormat,
+		"format",
+		"",
+		"Format to print work in")
 }
 
 func callService() error {
-	config := model.NewConfig(providedAuthor, providedDuration)
+	config := model.NewConfig(providedAuthor, providedFormat, providedDuration)
 	if err := wlService.Congfigure(config); err != nil {
 		return err
 	}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -46,6 +46,13 @@ worklog application.`,
 		if providedDuration < 0 {
 			providedDuration = defaultDuration
 		}
+		if providedFormat != "" &&
+			providedFormat != "pretty" &&
+			providedFormat != "json" &&
+			providedFormat != "yaml" &&
+			providedFormat != "yml" {
+			return errors.New("provided format is not valid")
+		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,7 +78,7 @@ func init() {
 		&providedFormat,
 		"format",
 		"",
-		"Format to print work in")
+		"Format to print work in. If provided, must be one of 'pretty', 'yaml', 'json'")
 }
 
 func callService() error {

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -7,14 +7,20 @@ import (
 
 	"github.com/PossibleLlama/worklog/helpers"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var startDate time.Time
 var startDateString string
 var endDate time.Time
 var endDateString string
+
 var today bool
 var thisWeek bool
+
+var yamlOutput bool
+var jsonOutput bool
+var prettyOutput bool
 
 // printCmd represents the print command
 var printCmd = &cobra.Command{
@@ -24,8 +30,9 @@ var printCmd = &cobra.Command{
 been created between the dates provided.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if err := verifyDates(); err != nil {
-				return err
-			}
+			return err
+		}
+		verifySingleFormat()
 
 		return nil
 	},
@@ -67,6 +74,25 @@ func init() {
 		"",
 		false,
 		"Prints this weeks work")
+	printCmd.Flags().BoolVarP(
+		&prettyOutput,
+		"pretty",
+		"",
+		false,
+		"Output in a text format")
+	printCmd.Flags().BoolVarP(
+		&yamlOutput,
+		"yaml",
+		"",
+		false,
+		"Output in a yaml format")
+	printCmd.Flags().BoolVarP(
+		&jsonOutput,
+		"json",
+		"",
+		false,
+		"Output in a json format")
+}
 
 func verifyDates() error {
 	if len(startDateString) != 0 {
@@ -92,4 +118,25 @@ func verifyDates() error {
 		return errors.New("one flag is required")
 	}
 	return nil
+}
+
+// verifySingleFormat ensures that there is only 1 output format used.
+func verifySingleFormat() {
+	if !prettyOutput && !yamlOutput && !jsonOutput {
+		defaultFormat := viper.GetString("format")
+		if defaultFormat == "yaml" || defaultFormat == "yml" {
+			yamlOutput = true
+		} else if defaultFormat == "json" {
+			jsonOutput = true
+		} else {
+			prettyOutput = true
+		}
+	} else {
+		if prettyOutput {
+			yamlOutput = false
+			jsonOutput = false
+		} else if yamlOutput {
+			jsonOutput = false
+		}
+	}
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -29,12 +29,8 @@ var printCmd = &cobra.Command{
 	Long: `Prints all worklogs to console that have
 been created between the dates provided.`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if err := verifyDates(); err != nil {
-			return err
-		}
 		verifySingleFormat()
-
-		return nil
+		return verifyDates()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		worklogs, _, err := wlService.GetWorklogsBetween(startDate, endDate)

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
+	"os"
 	"time"
 
 	"github.com/PossibleLlama/worklog/helpers"
+	"github.com/PossibleLlama/worklog/model"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,8 +39,12 @@ been created between the dates provided.`,
 			return err
 		}
 
-		for _, work := range worklogs {
-			fmt.Printf("%+v\n", work)
+		if prettyOutput {
+			model.WriteAllWorkToText(os.Stdout, worklogs)
+		} else if yamlOutput {
+			model.WriteAllWorkToYAML(os.Stdout, worklogs)
+		} else {
+			model.WriteAllWorkToJSON(os.Stdout, worklogs)
 		}
 		return nil
 	},
@@ -119,7 +124,7 @@ func verifyDates() error {
 // verifySingleFormat ensures that there is only 1 output format used.
 func verifySingleFormat() {
 	if !prettyOutput && !yamlOutput && !jsonOutput {
-		defaultFormat := viper.GetString("format")
+		defaultFormat := viper.GetString("default.format")
 		if defaultFormat == "yaml" || defaultFormat == "yml" {
 			yamlOutput = true
 		} else if defaultFormat == "json" {

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -23,28 +23,10 @@ var printCmd = &cobra.Command{
 	Long: `Prints all worklogs to console that have
 been created between the dates provided.`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(startDateString) != 0 {
-			startDateAnytime, err := helpers.GetStringAsDateTime(startDateString)
-			if err != nil {
+		if err := verifyDates(); err != nil {
 				return err
 			}
-			startDate = helpers.Midnight(startDateAnytime)
-			if len(endDateString) != 0 {
-				endDateAnytime, err := helpers.GetStringAsDateTime(endDateString)
-				if err != nil {
-					return err
-				}
-				endDate = helpers.Midnight(endDateAnytime).AddDate(0, 0, 1)
-			}
-		} else if today {
-			startDate = helpers.Midnight(time.Now())
-			endDate = startDate.AddDate(0, 0, 1)
-		} else if thisWeek {
-			startDate = helpers.Midnight(helpers.GetPreviousMonday(time.Now()))
-			endDate = startDate.AddDate(0, 0, 7)
-		} else {
-			return errors.New("one flag is required")
-		}
+
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,4 +67,29 @@ func init() {
 		"",
 		false,
 		"Prints this weeks work")
+
+func verifyDates() error {
+	if len(startDateString) != 0 {
+		startDateAnytime, err := helpers.GetStringAsDateTime(startDateString)
+		if err != nil {
+			return err
+		}
+		startDate = helpers.Midnight(startDateAnytime)
+		if len(endDateString) != 0 {
+			endDateAnytime, err := helpers.GetStringAsDateTime(endDateString)
+			if err != nil {
+				return err
+			}
+			endDate = helpers.Midnight(endDateAnytime).AddDate(0, 0, 1)
+		}
+	} else if today {
+		startDate = helpers.Midnight(time.Now())
+		endDate = startDate.AddDate(0, 0, 1)
+	} else if thisWeek {
+		startDate = helpers.Midnight(helpers.GetPreviousMonday(time.Now()))
+		endDate = startDate.AddDate(0, 0, 7)
+	} else {
+		return errors.New("one flag is required")
+	}
+	return nil
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -19,9 +19,9 @@ var endDateString string
 var today bool
 var thisWeek bool
 
+var prettyOutput bool
 var yamlOutput bool
 var jsonOutput bool
-var prettyOutput bool
 
 // printCmd represents the print command
 var printCmd = &cobra.Command{

--- a/helpers/version.go
+++ b/helpers/version.go
@@ -2,5 +2,5 @@ package helpers
 
 const (
 	// Version keep track of the version of the application
-	Version string = "0.3.2"
+	Version string = "0.3.3"
 )

--- a/model/config.go
+++ b/model/config.go
@@ -14,6 +14,12 @@ type Config struct {
 
 // NewConfig is the generator for configuration
 func NewConfig(author, format string, duration int) *Config {
+	if format != "pretty" &&
+		format != "json" &&
+		format != "yaml" &&
+		format != "yml" {
+		format = ""
+	}
 	return &Config{
 		Author: author,
 		Defaults: Defaults{

--- a/model/config.go
+++ b/model/config.go
@@ -2,7 +2,8 @@ package model
 
 // Defaults all options available as defaults in the configuration
 type Defaults struct {
-	Duration int
+	Duration int    `yaml:"duration"`
+	Format   string `yaml:"format,omitempty"`
 }
 
 // Config all options available in the configuration
@@ -12,11 +13,12 @@ type Config struct {
 }
 
 // NewConfig is the generator for configuration
-func NewConfig(author string, duration int) *Config {
+func NewConfig(author, format string, duration int) *Config {
 	return &Config{
 		Author: author,
 		Defaults: Defaults{
 			Duration: duration,
+			Format:   format,
 		},
 	}
 }

--- a/model/work.go
+++ b/model/work.go
@@ -12,14 +12,23 @@ import (
 // stores information as to what
 // work was done by who and when.
 type Work struct {
-	Title       string
-	Description string
-	Author      string
-	Where       string
-	Duration    int
-	Tags        []string
-	When        time.Time
-	Created     time.Time
+	Title       string    `json:"title" yaml:"title"`
+	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Author      string    `json:"author,omitempty" yaml:"author,omitempty"`
+	Where       string    `json:"where,omitempty" yaml:"where,omitempty"`
+	Duration    int       `json:"duration" yaml:"duration"`
+	Tags        []string  `json:"tags,flow,omitempty" yaml:"tags,flow,omitempty"`
+	When        time.Time `json:"when" yaml:"when"`
+	CreatedAt   time.Time `json:"createdAt" yaml:"createdAt"`
+}
+
+type printWork struct {
+	Title       string    `json:"title" yaml:"title"`
+	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Author      string    `json:"author,omitempty" yaml:"author,omitempty"`
+	Duration    int       `json:"duration" yaml:"duration"`
+	Tags        []string  `json:"tags,flow,omitempty" yaml:"tags,flow,omitempty"`
+	When        time.Time `json:"when" yaml:"when"`
 }
 
 // NewWork is the generator for work.
@@ -39,26 +48,45 @@ func NewWork(title, description, author string, duration int, tags []string, whe
 		Duration:    duration,
 		Tags:        tags,
 		When:        when,
-		Created:     now,
+		CreatedAt:   now,
 	}
 }
 
+func workToPrintWork(w Work) printWork {
+	return printWork{
+		Title:       w.Title,
+		Description: w.Description,
+		Author:      w.Author,
+		Duration:    w.Duration,
+		Tags:        w.Tags,
+		When:        w.When,
+	}
+}
+
+// String generates a stringified version of the Work
 func (w Work) String() string {
+	pw := workToPrintWork(w)
 	finalString := " "
-	if w.Title != "" {
-		finalString = fmt.Sprintf("%s Title: %s,", finalString, w.Title)
+	if pw.Title != "" {
+		finalString = fmt.Sprintf("%s Title: %s,", finalString, pw.Title)
 	}
-	if w.Description != "" {
-		finalString = fmt.Sprintf("%s Description: %s,", finalString, w.Description)
+	if pw.Description != "" {
+		finalString = fmt.Sprintf("%s Description: %s,", finalString, pw.Description)
 	}
-	if w.Author != "" {
-		finalString = fmt.Sprintf("%s Author: %s,", finalString, w.Author)
+	if pw.Author != "" {
+		finalString = fmt.Sprintf("%s Author: %s,", finalString, pw.Author)
 	}
-	if w.Where != "" {
-		finalString = fmt.Sprintf("%s Where: %s,", finalString, w.Where)
+	if pw.Duration != 0 {
+		finalString = fmt.Sprintf("%s Duration: %d,", finalString, pw.Duration)
 	}
-	if w.Duration != 0 {
-		finalString = fmt.Sprintf("%s Duration: %d,", finalString, w.Duration)
+	if len(pw.Tags) > 0 {
+		finalString = fmt.Sprintf("%s Tags: [%s],", finalString, strings.Join(pw.Tags, ", "))
+	}
+	if !pw.When.Equal(time.Time{}) {
+		finalString = fmt.Sprintf("%s When: %s,", finalString, pw.When)
+	}
+	return strings.TrimSpace(finalString[:len(finalString)-1])
+}
 	}
 	if len(w.Tags) > 0 {
 		finalString = fmt.Sprintf("%s Tags: %s,", finalString, strings.Join(w.Tags, ", "))

--- a/model/work.go
+++ b/model/work.go
@@ -149,6 +149,22 @@ func (w Work) WriteYAML(writer io.Writer) error {
 	return err
 }
 
+// WriteAllWorkToYAML takes a writer and list of work, and outputs a YAML representation of Work to the writer
+func WriteAllWorkToYAML(writer io.Writer, w []*Work) error {
+	pw := []printWork{}
+	for _, work := range w {
+		pw = append(pw, workToPrintWork(*work))
+	}
+
+	b, err := yaml.Marshal(pw)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	return err
+}
+
 // WriteJSON takes a writer and outputs a JSON representation of Work to it
 func (w Work) WriteJSON(writer io.Writer) error {
 	b, err := json.Marshal(workToPrintWork(w))

--- a/model/work.go
+++ b/model/work.go
@@ -159,3 +159,19 @@ func (w Work) WriteJSON(writer io.Writer) error {
 	_, err = writer.Write(b)
 	return err
 }
+
+// WriteAllWorkToJSON takes a writer and list of work, and outputs a JSON representation of Work to the writer
+func WriteAllWorkToJSON(writer io.Writer, w []*Work) error {
+	pw := []printWork{}
+	for _, work := range w {
+		pw = append(pw, workToPrintWork(*work))
+	}
+
+	b, err := json.Marshal(pw)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	return err
+}

--- a/model/work.go
+++ b/model/work.go
@@ -1,11 +1,15 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Work data model.
@@ -87,15 +91,31 @@ func (w Work) String() string {
 	}
 	return strings.TrimSpace(finalString[:len(finalString)-1])
 }
+
+// WriteText takes a writer and outputs a text representation of Work to it
+func (w Work) WriteText(writer io.Writer) error {
+	_, err := writer.Write([]byte(w.String()))
+	return err
+}
+
+// WriteYAML takes a writer and outputs a YAML representation of Work to it
+func (w Work) WriteYAML(writer io.Writer) error {
+	b, err := yaml.Marshal(workToPrintWork(w))
+	if err != nil {
+		return err
 	}
-	if len(w.Tags) > 0 {
-		finalString = fmt.Sprintf("%s Tags: %s,", finalString, strings.Join(w.Tags, ", "))
+
+	_, err = writer.Write(b)
+	return err
+}
+
+// WriteJSON takes a writer and outputs a JSON representation of Work to it
+func (w Work) WriteJSON(writer io.Writer) error {
+	b, err := json.Marshal(workToPrintWork(w))
+	if err != nil {
+		return err
 	}
-	if !w.When.Equal(time.Time{}) {
-		finalString = fmt.Sprintf("%s When: %s,", finalString, w.When)
-	}
-	if !w.Created.Equal(time.Time{}) {
-		finalString = fmt.Sprintf("%s Created: %s,", finalString, w.Created)
-	}
-	return strings.TrimSpace(finalString[:len(finalString)-1])
+
+	_, err = writer.Write(b)
+	return err
 }

--- a/model/work.go
+++ b/model/work.go
@@ -92,10 +92,50 @@ func (w Work) String() string {
 	return strings.TrimSpace(finalString[:len(finalString)-1])
 }
 
+// PrettyString works like string, but with greater spacing and line breaks
+func (w Work) PrettyString() string {
+	pw := workToPrintWork(w)
+	finalString := " "
+	if pw.Title != "" {
+		finalString = fmt.Sprintf("%sTitle: %s\n", finalString, pw.Title)
+	}
+	if pw.Description != "" {
+		finalString = fmt.Sprintf("%sDescription: %s\n", finalString, pw.Description)
+	}
+	if pw.Author != "" {
+		finalString = fmt.Sprintf("%sAuthor: %s\n", finalString, pw.Author)
+	}
+	if pw.Duration != 0 {
+		finalString = fmt.Sprintf("%sDuration: %d\n", finalString, pw.Duration)
+	}
+	if len(pw.Tags) > 0 {
+		finalString = fmt.Sprintf("%sTags: [%s]\n", finalString, strings.Join(pw.Tags, ", "))
+	}
+	if !pw.When.Equal(time.Time{}) {
+		finalString = fmt.Sprintf("%sWhen: %s\n", finalString, pw.When)
+	}
+	return strings.TrimSpace(finalString[:len(finalString)-1])
+}
+
 // WriteText takes a writer and outputs a text representation of Work to it
 func (w Work) WriteText(writer io.Writer) error {
-	_, err := writer.Write([]byte(w.String()))
+	_, err := writer.Write([]byte(w.PrettyString()))
 	return err
+}
+
+// WriteAllWorkToText takes a writer and list of work, and outputs a text representation of Work to the writer
+func WriteAllWorkToText(writer io.Writer, w []*Work) error {
+	for index, work := range w {
+		err := work.WriteText(os.Stdout)
+		if err != nil {
+			return err
+		}
+		if index != len(w)-1 {
+			fmt.Println()
+		}
+		fmt.Println()
+	}
+	return nil
 }
 
 // WriteYAML takes a writer and outputs a YAML representation of Work to it

--- a/model/work_test.go
+++ b/model/work_test.go
@@ -96,12 +96,12 @@ func TestNewWork(t *testing.T) {
 				}
 			}
 			if !actual.When.Equal(testItem.expected.When) {
-				t.Errorf("Should have when '%s', instead has '%s'", actual.When, actual.Created)
+				t.Errorf("Should have when '%s', instead has '%s'", actual.When, actual.CreatedAt)
 			}
-			if time.Since(actual.Created) < time.Since(before) {
+			if time.Since(actual.CreatedAt) < time.Since(before) {
 				t.Error("Was not created after start of test")
 			}
-			if time.Since(actual.Created) < time.Since(after) {
+			if time.Since(actual.CreatedAt) < time.Since(after) {
 				t.Error("Was not created before end of test")
 			}
 		})

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -107,8 +107,6 @@ func createFile(fileName string) (*os.File, error) {
 }
 
 func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time) ([]*model.Work, error) {
-	fmt.Println("Retrieving files...")
-
 	var worklogs []*model.Work
 	var errors []string
 


### PR DESCRIPTION
Allow for the `print` command to output in various formats, including yaml, json and pretty.

Example outputs (to console) as follows.

### Pretty
```text
Title: Foo
Description: I am a long description
Author: Alice
Duration: 15
Tags: [a, b]
When: 2000-01-01 00:00:01 +0000 UTC
```

### Yaml
```yaml
- title: Foo
  description: I am a long description
  author: Alice
  duration: 15
  tags: [a, b]
  when: 2000-01-01T00:00:01Z
```

### JSON
```json
[{"title":"Foo","description":"I am a long description","author":"Alice","duration":15,"tags":["a","b"],"when":"2000-01-01T00:00:01Z"}]
```