### PR TITLE
022 Refactor io

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -42,9 +42,9 @@ been created between the dates provided.`,
 		if prettyOutput {
 			model.WriteAllWorkToPrettyText(os.Stdout, worklogs)
 		} else if yamlOutput {
-			model.WriteAllWorkToYAML(os.Stdout, worklogs)
+			model.WriteAllWorkToPrettyYAML(os.Stdout, worklogs)
 		} else {
-			model.WriteAllWorkToJSON(os.Stdout, worklogs)
+			model.WriteAllWorkToPrettyJSON(os.Stdout, worklogs)
 		}
 		return nil
 	},

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -40,7 +40,7 @@ been created between the dates provided.`,
 		}
 
 		if prettyOutput {
-			model.WriteAllWorkToText(os.Stdout, worklogs)
+			model.WriteAllWorkToPrettyText(os.Stdout, worklogs)
 		} else if yamlOutput {
 			model.WriteAllWorkToYAML(os.Stdout, worklogs)
 		} else {

--- a/model/config.go
+++ b/model/config.go
@@ -1,5 +1,11 @@
 package model
 
+import (
+	"io"
+
+	"gopkg.in/yaml.v2"
+)
+
 // Defaults all options available as defaults in the configuration
 type Defaults struct {
 	Duration int    `yaml:"duration"`
@@ -27,4 +33,15 @@ func NewConfig(author, format string, duration int) *Config {
 			Format:   format,
 		},
 	}
+}
+
+// WriteYAML takes a writer and outputs a YAML representation of Config to it
+func (c Config) WriteYAML(writer io.Writer) error {
+	b, err := yaml.Marshal(&c)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	return err
 }

--- a/model/work.go
+++ b/model/work.go
@@ -158,6 +158,12 @@ func (w Work) WriteYAML(writer io.Writer) error {
 	return err
 }
 
+// ReadYAML takes a string and parses into Work
+func ReadYAML(input []byte) (*Work, error) {
+	var w Work
+	return &w, yaml.Unmarshal(input, &w)
+}
+
 // WritePrettyYAML takes a writer and outputs a YAML representation of Work to it
 func (w Work) WritePrettyYAML(writer io.Writer) error {
 	b, err := yaml.Marshal(workToPrintWork(w))

--- a/model/work.go
+++ b/model/work.go
@@ -122,14 +122,20 @@ func (w Work) PrettyString() string {
 
 // WriteText takes a writer and outputs a text representation of Work to it
 func (w Work) WriteText(writer io.Writer) error {
+	_, err := writer.Write([]byte(w.String()))
+	return err
+}
+
+// WritePrettyText takes a writer and outputs a text representation of Work to it
+func (w Work) WritePrettyText(writer io.Writer) error {
 	_, err := writer.Write([]byte(w.PrettyString()))
 	return err
 }
 
-// WriteAllWorkToText takes a writer and list of work, and outputs a text representation of Work to the writer
-func WriteAllWorkToText(writer io.Writer, w []*Work) error {
+// WriteAllWorkToPrettyText takes a writer and list of work, and outputs a text representation of Work to the writer
+func WriteAllWorkToPrettyText(writer io.Writer, w []*Work) error {
 	for index, work := range w {
-		err := work.WriteText(os.Stdout)
+		err := work.WritePrettyText(os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/model/work.go
+++ b/model/work.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PossibleLlama/worklog/helpers"
 	"gopkg.in/yaml.v2"
 )
 
@@ -69,25 +70,27 @@ func workToPrintWork(w Work) printWork {
 
 // String generates a stringified version of the Work
 func (w Work) String() string {
-	pw := workToPrintWork(w)
 	finalString := " "
-	if pw.Title != "" {
-		finalString = fmt.Sprintf("%s Title: %s,", finalString, pw.Title)
+	if w.Title != "" {
+		finalString = fmt.Sprintf("%s Title: %s,", finalString, w.Title)
 	}
-	if pw.Description != "" {
-		finalString = fmt.Sprintf("%s Description: %s,", finalString, pw.Description)
+	if w.Description != "" {
+		finalString = fmt.Sprintf("%s Description: %s,", finalString, w.Description)
 	}
-	if pw.Author != "" {
-		finalString = fmt.Sprintf("%s Author: %s,", finalString, pw.Author)
+	if w.Author != "" {
+		finalString = fmt.Sprintf("%s Author: %s,", finalString, w.Author)
 	}
-	if pw.Duration != 0 {
-		finalString = fmt.Sprintf("%s Duration: %d,", finalString, pw.Duration)
+	if w.Duration != 0 {
+		finalString = fmt.Sprintf("%s Duration: %d,", finalString, w.Duration)
 	}
-	if len(pw.Tags) > 0 {
-		finalString = fmt.Sprintf("%s Tags: [%s],", finalString, strings.Join(pw.Tags, ", "))
+	if len(w.Tags) > 0 {
+		finalString = fmt.Sprintf("%s Tags: [%s],", finalString, strings.Join(w.Tags, ", "))
 	}
-	if !pw.When.Equal(time.Time{}) {
-		finalString = fmt.Sprintf("%s When: %s,", finalString, pw.When)
+	if !w.When.Equal(time.Time{}) {
+		finalString = fmt.Sprintf("%s When: %s,", finalString, helpers.TimeFormat(w.When))
+	}
+	if !w.CreatedAt.Equal(time.Time{}) {
+		finalString = fmt.Sprintf("%s CreatedAt: %s", finalString, helpers.TimeFormat(w.CreatedAt))
 	}
 	return strings.TrimSpace(finalString[:len(finalString)-1])
 }
@@ -112,7 +115,7 @@ func (w Work) PrettyString() string {
 		finalString = fmt.Sprintf("%sTags: [%s]\n", finalString, strings.Join(pw.Tags, ", "))
 	}
 	if !pw.When.Equal(time.Time{}) {
-		finalString = fmt.Sprintf("%sWhen: %s\n", finalString, pw.When)
+		finalString = fmt.Sprintf("%sWhen: %s\n", finalString, helpers.TimeFormat(pw.When))
 	}
 	return strings.TrimSpace(finalString[:len(finalString)-1])
 }

--- a/model/work.go
+++ b/model/work.go
@@ -149,6 +149,17 @@ func WriteAllWorkToPrettyText(writer io.Writer, w []*Work) error {
 
 // WriteYAML takes a writer and outputs a YAML representation of Work to it
 func (w Work) WriteYAML(writer io.Writer) error {
+	b, err := yaml.Marshal(w)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	return err
+}
+
+// WritePrettyYAML takes a writer and outputs a YAML representation of Work to it
+func (w Work) WritePrettyYAML(writer io.Writer) error {
 	b, err := yaml.Marshal(workToPrintWork(w))
 	if err != nil {
 		return err
@@ -158,8 +169,8 @@ func (w Work) WriteYAML(writer io.Writer) error {
 	return err
 }
 
-// WriteAllWorkToYAML takes a writer and list of work, and outputs a YAML representation of Work to the writer
-func WriteAllWorkToYAML(writer io.Writer, w []*Work) error {
+// WriteAllWorkToPrettyYAML takes a writer and list of work, and outputs a YAML representation of Work to the writer
+func WriteAllWorkToPrettyYAML(writer io.Writer, w []*Work) error {
 	pw := []printWork{}
 	for _, work := range w {
 		pw = append(pw, workToPrintWork(*work))
@@ -176,6 +187,17 @@ func WriteAllWorkToYAML(writer io.Writer, w []*Work) error {
 
 // WriteJSON takes a writer and outputs a JSON representation of Work to it
 func (w Work) WriteJSON(writer io.Writer) error {
+	b, err := json.Marshal(w)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	return err
+}
+
+// WritePrettyJSON takes a writer and outputs a JSON representation of Work to it
+func (w Work) WritePrettyJSON(writer io.Writer) error {
 	b, err := json.Marshal(workToPrintWork(w))
 	if err != nil {
 		return err
@@ -185,8 +207,8 @@ func (w Work) WriteJSON(writer io.Writer) error {
 	return err
 }
 
-// WriteAllWorkToJSON takes a writer and list of work, and outputs a JSON representation of Work to the writer
-func WriteAllWorkToJSON(writer io.Writer, w []*Work) error {
+// WriteAllWorkToPrettyJSON takes a writer and list of work, and outputs a JSON representation of Work to the writer
+func WriteAllWorkToPrettyJSON(writer io.Writer, w []*Work) error {
 	pw := []printWork{}
 	for _, work := range w {
 		pw = append(pw, workToPrintWork(*work))

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -154,14 +154,13 @@ func getAllFileNamesBetweenDates(startDate, endDate time.Time) ([]string, error)
 }
 
 func parseFileToWork(filePath string) (*model.Work, error) {
-	var worklog model.Work
 	yamlFile, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file %s. %e", filePath, err)
 	}
-	err = yaml.Unmarshal(yamlFile, &worklog)
+	worklog, err := model.ReadYAML(yamlFile)
 	if err == nil {
 		sort.Strings(worklog.Tags)
 	}
-	return &worklog, err
+	return worklog, err
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/PossibleLlama/worklog/helpers"
 	"github.com/PossibleLlama/worklog/model"
 	homedir "github.com/mitchellh/go-homedir"
-	"gopkg.in/yaml.v2"
 )
 
 type yamlFileRepo struct{}
@@ -33,11 +32,9 @@ func (*yamlFileRepo) Configure(cfg *model.Config) error {
 		return fmt.Errorf("unable to create configuration file. %s", err.Error())
 	}
 
-	bytes, err := yaml.Marshal(&cfg)
-	if err != nil {
+	if err := cfg.WriteYAML(file); err != nil {
 		return fmt.Errorf("unable to save config. %s", err.Error())
 	}
-	file.Write(bytes)
 	file.Sync()
 
 	return nil

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -52,11 +52,9 @@ func (*yamlFileRepo) Save(wl *model.Work) error {
 		return fmt.Errorf("unable to save worklog. %s", err.Error())
 	}
 
-	bytes, err := yaml.Marshal(*wl)
-	if err != nil {
+	if err := wl.WriteYAML(file); err != nil {
 		return fmt.Errorf("unable to save worklog. %s", err.Error())
 	}
-	file.Write(bytes)
 	file.Sync()
 
 	fmt.Println("Saved file")


### PR DESCRIPTION
Make it clearer that some writer functions are for a pretty version of `Work`, whereas others include the full `Work` struct.

The full version can then be used within the yamlRepo to store work, and a reader method can be used to convert from yaml back into a Work struct.

There will also be yaml writer functions for the configuration, which will in turn mean that the yamlRepo file will only know it's a file writer, and not care that it is specific to yaml.
