### PR TITLE
024 Print filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ rm worklog.exe
 
 ## Creating worklogs
 
+``` bash
+worklog create <FLAGS>
+```
+
 To create a basic worklog, you can use `worklog create --title "foo"`.
 This will create an item of work, with the current timestamp, and the
 name `"foo"`.
@@ -54,9 +58,26 @@ You can specify further fields as you want to.
 
 [RFC3339]: https://tools.ietf.org/html/rfc3339
 
+### Example create
+
+``` bash
+worklog create \
+--title "Wake up" \
+--description "A detailed description of my morning routine."
+--duration 60
+--tags "morning"
+```
+
 ## Reading worklogs
 
-Printing worklogs to the console. You can use `worklog print <FLAGS>`.
+``` bash
+worklog print <DATE> <FILTERS> <FORMAT>
+```
+
+Printing all worklogs to the console that match your criteria.
+
+### Date
+
 One of the following must be provided within the flags.
 
 - `--startDate "2000/12/31"` Print all work completed after this
@@ -68,18 +89,53 @@ One of the following must be provided within the flags.
 - `--thisWeek` Print all work completed since midnight on the last
   Monday. This is not the last 168 hours.
 
-In addition to the flags above, you can provide 1 of the following
-which will change how the output is formatted.
+### Filters
+
+You can specify as many of these as you need to search for the correct
+worklogs.
+
+All filters:
+
+- Are case insensitive.
+- Will include partial matches (`--title "a"` will return all titles
+  that include an "a" anywhere within the title.)
+- Any returned Work must satisfy all filters.
+
+Arguments match the names used when creating a worklog.
+
+Valid arguments are:
+
+- `--title`
+- `--description`
+- `--author`
+- `--tags`
+
+### Format
+
+Optionally, you can provide 1 of the following which will change how
+the output is formatted.
 
 - `--pretty` Output format is text. (Default)
 - `--yaml` Output format is yaml.
 - `--json` Output format is json.
 
+### Example print
+
+``` bash
+worklog print --today --json --tags "morning"
+```
+
 ## Configuration
+
+``` bash
+worklog configure
+```
 
 Configuration for the application.
 
 For basic setup you can run `worklog configure`.
+This will provide an empty string for the author, and a
+duration of 15.
 
 For more advanced setup, `worklog configure defaults <FLAGS>`
 will add provided flags into the configuration.
@@ -87,7 +143,13 @@ will add provided flags into the configuration.
 - `--author "Alice"` String of the author's name.
 - `--duration 15` Default duration that a task takes.
 - `--format "json"` Default format to print output.
-  Accepts pretty, yaml or json.
+  Accepts `"pretty"`, `"yaml"` or `"json"`.
+
+### Example configure
+
+``` bash
+worklog configure defaults --author "Alice" --duration 30 --format "pretty"
+```
 
 ### Example file
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ have done each day.
 
 ## Supported versions
 
-- v0.3.4
+- v0.3.5
 
 ## Installation
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/PossibleLlama/worklog/helpers"
@@ -20,6 +21,12 @@ var endDateString string
 var today bool
 var thisWeek bool
 
+var titleFilter string
+var descriptionFilter string
+var authorFilter string
+var rawTagsFilter string
+var tagsFilter []string
+
 var prettyOutput bool
 var yamlOutput bool
 var jsonOutput bool
@@ -32,10 +39,18 @@ var printCmd = &cobra.Command{
 been created between the dates provided.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		verifySingleFormat()
+		verifyFilters()
 		return verifyDates()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		worklogs, _, err := wlService.GetWorklogsBetween(startDate, endDate)
+		filter := model.NewWork(
+			titleFilter,
+			descriptionFilter,
+			authorFilter,
+			-1,
+			tagsFilter,
+			time.Time{})
+		worklogs, _, err := wlService.GetWorklogsBetween(startDate, endDate, filter)
 		if err != nil {
 			return err
 		}
@@ -56,6 +71,7 @@ been created between the dates provided.`,
 func init() {
 	rootCmd.AddCommand(printCmd)
 
+	// Dates
 	printCmd.Flags().StringVar(
 		&startDateString,
 		"startDate",
@@ -78,6 +94,30 @@ func init() {
 		"",
 		false,
 		"Prints this weeks work")
+
+	// Filters
+	printCmd.Flags().StringVar(
+		&titleFilter,
+		"title",
+		"",
+		"Filter by work including title")
+	printCmd.Flags().StringVar(
+		&descriptionFilter,
+		"description",
+		"",
+		"Filter by work including description")
+	printCmd.Flags().StringVar(
+		&authorFilter,
+		"author",
+		"",
+		"Filter by work including author")
+	printCmd.Flags().StringVar(
+		&rawTagsFilter,
+		"tags",
+		"",
+		"Filter by work including all tags")
+
+	// Format
 	printCmd.Flags().BoolVarP(
 		&prettyOutput,
 		"pretty",
@@ -122,6 +162,18 @@ func verifyDates() error {
 		return errors.New("one flag is required")
 	}
 	return nil
+}
+
+// verifyFilters ensures that the filters make sense
+func verifyFilters() {
+	titleFilter = strings.TrimSpace(titleFilter)
+	descriptionFilter = strings.TrimSpace(descriptionFilter)
+	authorFilter = strings.TrimSpace(authorFilter)
+	tagsFilter = strings.Split(rawTagsFilter, ",")
+
+	for _, tag := range tagsFilter {
+		tag = strings.TrimSpace(tag)
+	}
 }
 
 // verifySingleFormat ensures that there is only 1 output format used.

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -55,8 +55,9 @@ been created between the dates provided.`,
 			return err
 		}
 
-		if len(worklogs) == 0 {
-			fmt.Printf("No work found between %s and %s\n", startDate, endDate.Add(time.Second*-1))
+		if len(worklogs) == 0 && !jsonOutput {
+			fmt.Printf("No work found between %s and %s with the given filter\n",
+				startDate, endDate.Add(time.Second*-1))
 		} else if prettyOutput {
 			model.WriteAllWorkToPrettyText(os.Stdout, worklogs)
 		} else if yamlOutput {

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -169,10 +169,10 @@ func verifyFilters() {
 	titleFilter = strings.TrimSpace(titleFilter)
 	descriptionFilter = strings.TrimSpace(descriptionFilter)
 	authorFilter = strings.TrimSpace(authorFilter)
-	tagsFilter = strings.Split(rawTagsFilter, ",")
+	rawTagsList := strings.Split(rawTagsFilter, ",")
 
-	for _, tag := range tagsFilter {
-		tag = strings.TrimSpace(tag)
+	for _, tag := range rawTagsList {
+		tagsFilter = append(tagsFilter, strings.TrimSpace(tag))
 	}
 }
 

--- a/helpers/version.go
+++ b/helpers/version.go
@@ -2,5 +2,5 @@ package helpers
 
 const (
 	// Version keep track of the version of the application
-	Version string = "0.3.4"
+	Version string = "0.3.5"
 )

--- a/repository/repositories.go
+++ b/repository/repositories.go
@@ -12,5 +12,5 @@ type WorklogRepository interface {
 	Configure(cfg *model.Config) error
 	Save(wl *model.Work) error
 
-	GetAllBetweenDates(startDate, endDate time.Time) ([]*model.Work, error)
+	GetAllBetweenDates(startDate, endDate time.Time, filter *model.Work) ([]*model.Work, error)
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -114,7 +114,7 @@ func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time, filter *mo
 		readWorklog, err := parseFileToWork(fileName)
 		if err != nil {
 			errors = append(errors, err.Error())
-		} else {
+		} else if workMatchesFilter(filter, readWorklog) {
 			worklogs = append(worklogs, readWorklog)
 		}
 	}
@@ -160,4 +160,31 @@ func parseFileToWork(filePath string) (*model.Work, error) {
 		sort.Strings(worklog.Tags)
 	}
 	return worklog, err
+}
+
+func workMatchesFilter(filter, w *model.Work) bool {
+	if !aInB(filter.Title, w.Title) {
+		return false
+	}
+	if !aInB(filter.Description, w.Description) {
+		return false
+	}
+	if !aInB(filter.Author, w.Author) {
+		return false
+	}
+	for _, filtersTag := range filter.Tags {
+		if filtersTag == "" {
+			continue
+		}
+		if !aInB(filtersTag, strings.Join(w.Tags, " ")) {
+			return false
+		}
+	}
+	return true
+}
+
+func aInB(a, b string) bool {
+	return a == "" || strings.Contains(
+		strings.ToLower(b),
+		strings.ToLower(a))
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -173,10 +173,8 @@ func workMatchesFilter(filter, w *model.Work) bool {
 		return false
 	}
 	for _, filtersTag := range filter.Tags {
-		if filtersTag == "" {
-			continue
-		}
-		if !aInB(filtersTag, strings.Join(w.Tags, " ")) {
+		if filtersTag != "" &&
+			!aInB(filtersTag, strings.Join(w.Tags, " ")) {
 			return false
 		}
 	}

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -101,7 +101,7 @@ func createFile(fileName string) (*os.File, error) {
 	return file, nil
 }
 
-func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time) ([]*model.Work, error) {
+func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time, filter *model.Work) ([]*model.Work, error) {
 	var worklogs []*model.Work
 	var errors []string
 

--- a/service/services.go
+++ b/service/services.go
@@ -13,7 +13,7 @@ import (
 type WorklogService interface {
 	Congfigure(cfg *model.Config) error
 	CreateWorklog(wl *model.Work) (int, error)
-	GetWorklogsBetween(start, end time.Time) ([]*model.Work, int, error)
+	GetWorklogsBetween(start, end time.Time, filter *model.Work) ([]*model.Work, int, error)
 }
 
 type service struct{}
@@ -39,8 +39,8 @@ func (*service) CreateWorklog(wl *model.Work) (int, error) {
 	return http.StatusCreated, nil
 }
 
-func (*service) GetWorklogsBetween(start, end time.Time) ([]*model.Work, int, error) {
-	worklogs, err := repo.GetAllBetweenDates(start, end)
+func (*service) GetWorklogsBetween(start, end time.Time, filter *model.Work) ([]*model.Work, int, error) {
+	worklogs, err := repo.GetAllBetweenDates(start, end, filter)
 	if err != nil {
 		return worklogs, http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
Add filter's into the print command.

Allow specifying of specific title's, descriptions, tags, and authors, or a combination of them.

The results will be what is between the given dates with the filter applied.

The issue mentioned a `--latest` flag which will return the most recently created worklog only.
This aspect has been rejected at the moment for a few reasons.

- There are already quite a few arguments that can be passed into the `print` command.
- The way the existing filters work you can get a single worklog through other filters.
- You could pull all back (without a filter) in a json format and pipe the output into `jq` (or similar) and select the last element.

---

### Updated

- [x] Readme
- [x] Version
