### PR TITLE
073 config cleanup

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -50,7 +50,7 @@ func ConfigRun(cmd *cobra.Command, args []string) error {
 
 func configRun() error {
 	cfg := model.NewConfig(configProvidedAuthor, configProvidedFormat, configProvidedDuration)
-	if err := wlService.Configure(cfg); err != nil {
+	if err := wlConfig.SaveConfig(cfg); err != nil {
 		return err
 	}
 	fmt.Println("Successfully configured")

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/PossibleLlama/worklog/helpers"
 	"github.com/PossibleLlama/worklog/model"
-	"github.com/PossibleLlama/worklog/service"
+	"github.com/PossibleLlama/worklog/repository"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,7 +50,7 @@ func TestConfigRun(t *testing.T) {
 		expErr   error
 	}{
 		{
-			name:     "Sends model to service",
+			name:     "Sends model directly to repo",
 			author:   helpers.RandAlphabeticString(shortLength),
 			duration: shortLength,
 			format:   "yaml",
@@ -67,18 +67,18 @@ func TestConfigRun(t *testing.T) {
 	for _, testItem := range tests {
 		cfg := model.NewConfig(testItem.author, testItem.format, testItem.duration)
 
-		mockService := new(service.MockService)
-		mockService.On("Configure", cfg).Return(testItem.expErr)
-		wlService = mockService
+		mockRepo := new(repository.MockRepo)
+		mockRepo.On("SaveConfig", cfg).Return(testItem.expErr)
+		wlConfig = mockRepo
 
 		t.Run(testItem.name, func(t *testing.T) {
 			setProvidedConfigureValues(testItem.author, testItem.format, testItem.duration)
 
 			actualErr := configRun()
 
-			mockService.AssertExpectations(t)
-			mockService.AssertCalled(t,
-				"Configure",
+			mockRepo.AssertExpectations(t)
+			mockRepo.AssertCalled(t,
+				"SaveConfig",
 				cfg)
 			assert.Equal(t, testItem.expErr, actualErr)
 		})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,6 @@ func initConfig() {
 	// If a config file is found, read it in
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Printf("Unable to use config file: '%s'. %s\n", viper.ConfigFileUsed(), err)
-		os.Exit(e.StartupErrors)
 	}
 
 	if repoType == "legacy" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 var (
 	wlService service.WorklogService
 	wlRepo    repository.WorklogRepository
+	wlConfig  repository.ConfigRepository
 )
 var (
 	homeDir      string
@@ -86,6 +87,8 @@ func init() {
 		// Temp
 		wlRepo = repository.NewYamlFileRepo()
 	}
+	wlConfig = repository.NewYamlConfig(
+		filepath.Dir(cfgFile))
 	wlService = service.NewWorklogService(wlRepo)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,17 +79,6 @@ func init() {
 		"Directory path for repository that worklogs are stored in")
 
 	cobra.OnInitialize(initConfig)
-
-	if repoType == "legacy" {
-		wlRepo = repository.NewYamlFileRepo()
-	} else {
-		// TODO
-		// Temp
-		wlRepo = repository.NewYamlFileRepo()
-	}
-	wlConfig = repository.NewYamlConfig(
-		filepath.Dir(cfgFile))
-	wlService = service.NewWorklogService(wlRepo)
 }
 
 // initConfig reads in config file and ENV variables if set
@@ -109,4 +98,15 @@ func initConfig() {
 		fmt.Printf("Unable to use config file: '%s'. %s\n", viper.ConfigFileUsed(), err)
 		os.Exit(e.StartupErrors)
 	}
+
+	if repoType == "legacy" {
+		wlRepo = repository.NewYamlFileRepo()
+	} else {
+		// TODO
+		// Temp
+		wlRepo = repository.NewYamlFileRepo()
+	}
+	wlConfig = repository.NewYamlConfig(
+		filepath.Dir(cfgFile))
+	wlService = service.NewWorklogService(wlRepo)
 }

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ func getActualConfig(t *testing.T) *model.Config {
 	if err != nil {
 		t.Error(err)
 	}
-	file, err := ioutil.ReadFile(fmt.Sprintf("%s/.worklog/config.yml", home))
+	file, err := ioutil.ReadFile(fmt.Sprintf("%s%s.worklog%sconfig.yml", home, string(filepath.Separator), string(filepath.Separator)))
 	if err != nil {
 		t.Error(err)
 	}
@@ -44,6 +45,12 @@ func getActualWork(t *testing.T, exp *model.Work, cfg *model.Config) *model.Work
 	if exp.Author == "" {
 		exp.Author = cfg.Defaults.Author
 	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		t.Error(err)
+	}
+	_ = repository.NewYamlConfig(fmt.Sprintf("%s%s.worklog%s", home, string(filepath.Separator), string(filepath.Separator)))
 	ymlRepo := repository.NewYamlFileRepo()
 	wls, _ := ymlRepo.GetAllBetweenDates(tmUTC.Add(time.Hour*1*-1), tmUTC.Add(time.Hour*1), exp)
 

--- a/repository/mockRepo.go
+++ b/repository/mockRepo.go
@@ -13,7 +13,7 @@ type MockRepo struct {
 }
 
 // Configure WorklogRepository method for testing
-func (m *MockRepo) Configure(cfg *model.Config) error {
+func (m *MockRepo) SaveConfig(cfg *model.Config) error {
 	args := m.Called(cfg)
 	return args.Error(0)
 }

--- a/repository/repositories.go
+++ b/repository/repositories.go
@@ -9,9 +9,12 @@ import (
 // WorklogRepository defines what a repository
 // for worklogs should be capable of doing
 type WorklogRepository interface {
-	Configure(cfg *model.Config) error
 	Save(wl *model.Work) error
 
 	GetAllBetweenDates(startDate, endDate time.Time, filter *model.Work) ([]*model.Work, error)
 	GetByID(id string, filter *model.Work) (*model.Work, error)
+}
+
+type ConfigRepository interface {
+	SaveConfig(cfg *model.Config) error
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -18,6 +18,8 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
+var configDir string
+
 type yamlFileRepo struct{}
 
 // NewYamlFileRepo Generator for repository storing worklogs
@@ -26,7 +28,12 @@ func NewYamlFileRepo() WorklogRepository {
 	return &yamlFileRepo{}
 }
 
-func (*yamlFileRepo) Configure(cfg *model.Config) error {
+func NewYamlConfig(dir string) ConfigRepository {
+	configDir = dir
+	return &yamlFileRepo{}
+}
+
+func (*yamlFileRepo) SaveConfig(cfg *model.Config) error {
 	if err := createDirectory(getWorklogDir()); err != nil {
 		return fmt.Errorf("%s %s. %s", e.RepoCreateDirectory, getWorklogDir(), err.Error())
 	}
@@ -89,6 +96,9 @@ func generateFileName(wl *model.Work) string {
 }
 
 func getWorklogDir() string {
+	if configDir != "" {
+		return configDir
+	}
 	home, err := homedir.Dir()
 	if err != nil {
 		fmt.Println(err)

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -14,8 +14,6 @@ import (
 	e "github.com/PossibleLlama/worklog/errors"
 	"github.com/PossibleLlama/worklog/helpers"
 	"github.com/PossibleLlama/worklog/model"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 var configDir string
@@ -29,15 +27,15 @@ func NewYamlFileRepo() WorklogRepository {
 }
 
 func NewYamlConfig(dir string) ConfigRepository {
-	configDir = dir
+	configDir = dir + string(filepath.Separator)
 	return &yamlFileRepo{}
 }
 
 func (*yamlFileRepo) SaveConfig(cfg *model.Config) error {
-	if err := createDirectory(getWorklogDir()); err != nil {
-		return fmt.Errorf("%s %s. %s", e.RepoCreateDirectory, getWorklogDir(), err.Error())
+	if err := createDirectory(configDir); err != nil {
+		return fmt.Errorf("%s %s. %s", e.RepoCreateDirectory, configDir, err.Error())
 	}
-	file, err := createFile(getWorklogDir() + "config.yml")
+	file, err := createFile(configDir + "config.yml")
 	if err != nil {
 		return fmt.Errorf("%s. %s", e.RepoConfigFileCreate, err.Error())
 	}
@@ -82,8 +80,6 @@ func (*yamlFileRepo) Save(wl *model.Work) error {
 }
 
 func generateFileName(wl *model.Work) string {
-	filePath := getWorklogDir()
-
 	fileName := fmt.Sprintf("%d-%02d-%02dT%02d:%02d_%d_%s",
 		wl.When.Year(),
 		int(wl.When.Month()),
@@ -92,19 +88,7 @@ func generateFileName(wl *model.Work) string {
 		wl.When.Minute(),
 		wl.Revision,
 		wl.ID)
-	return filePath + fileName + ".yml"
-}
-
-func getWorklogDir() string {
-	if configDir != "" {
-		return configDir
-	}
-	home, err := homedir.Dir()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(e.RepoErrors)
-	}
-	return home + "/.worklog/"
+	return configDir + fileName + ".yml"
 }
 
 func createDirectory(filePath string) error {
@@ -179,7 +163,7 @@ func (*yamlFileRepo) GetByID(ID string, filter *model.Work) (*model.Work, error)
 func getAllFileNamesBetweenDates(startDate, endDate time.Time) ([]string, error) {
 	var files []string
 
-	err := filepath.Walk(getWorklogDir(), func(fullPath string, info os.FileInfo, walkErr error) error {
+	err := filepath.Walk(configDir, func(fullPath string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -207,7 +191,7 @@ func getAllFileNamesBetweenDates(startDate, endDate time.Time) ([]string, error)
 func getFileByID(ID string) (string, error) {
 	ids := make(map[string]string)
 
-	err := filepath.Walk(getWorklogDir(), func(fullPath string, info os.FileInfo, err error) error {
+	err := filepath.Walk(configDir, func(fullPath string, info os.FileInfo, err error) error {
 		path := filepath.Base(fullPath)
 		if strings.Count(path, "_") < 2 {
 			return nil

--- a/service/mockService.go
+++ b/service/mockService.go
@@ -12,12 +12,6 @@ type MockService struct {
 	mock.Mock
 }
 
-// Configure WorklogService method for testing
-func (m *MockService) Configure(cfg *model.Config) error {
-	args := m.Called(cfg)
-	return args.Error(0)
-}
-
 // CreateWorklog WorklogService method for testing
 func (m *MockService) CreateWorklog(wl *model.Work) (int, error) {
 	args := m.Called(wl)

--- a/service/services.go
+++ b/service/services.go
@@ -8,7 +8,6 @@ import (
 
 // WorklogService defines what a service for worklogs should be capable of doing
 type WorklogService interface {
-	Configure(cfg *model.Config) error
 	CreateWorklog(wl *model.Work) (int, error)
 	EditWorklog(id string, newWl *model.Work) (int, error)
 	GetWorklogsBetween(start, end time.Time, filter *model.Work) ([]*model.Work, int, error)

--- a/service/worklogService.go
+++ b/service/worklogService.go
@@ -21,10 +21,6 @@ func NewWorklogService(repository repository.WorklogRepository) WorklogService {
 	return &service{}
 }
 
-func (*service) Configure(cfg *model.Config) error {
-	return repo.Configure(cfg)
-}
-
 func (*service) CreateWorklog(wl *model.Work) (int, error) {
 	if err := repo.Save(wl); err != nil {
 		return http.StatusInternalServerError, err

--- a/service/worklogService_test.go
+++ b/service/worklogService_test.go
@@ -37,13 +37,6 @@ func TestMain(m *testing.M) {
 	}
 }
 
-func genCfg() *model.Config {
-	return model.NewConfig(
-		helpers.RandAlphabeticString(strLength),
-		formats[rand.Intn(len(formats))],
-		int(src.Int63()))
-}
-
 func genWl() *model.Work {
 	tags := make([]string, src.Intn(arrLength)+1)
 	for index := range tags {
@@ -58,44 +51,6 @@ func genWl() *model.Work {
 		tags,
 		time.Now(),
 	)
-}
-
-func TestConfigure(t *testing.T) {
-	var tests = []struct {
-		name string
-		cfg  *model.Config
-		err  error
-	}{
-		{
-			name: "Success",
-			cfg:  genCfg(),
-			err:  nil,
-		},
-		{
-			name: "Errored",
-			cfg:  genCfg(),
-			err:  errors.New(helpers.RandAlphabeticString(strLength)),
-		},
-	}
-
-	for _, testItem := range tests {
-		mockRepo := new(repository.MockRepo)
-		mockRepo.On("Configure", testItem.cfg).
-			Return(testItem.err)
-		svc := NewWorklogService(mockRepo)
-
-		t.Run(testItem.name, func(t *testing.T) {
-			returnedErr := svc.Configure(testItem.cfg)
-
-			if returnedErr != nil {
-				assert.EqualError(t, testItem.err, returnedErr.Error())
-			} else {
-				assert.Nil(t, returnedErr)
-			}
-			mockRepo.AssertExpectations(t)
-			mockRepo.AssertCalled(t, "Configure", testItem.cfg)
-		})
-	}
 }
 
 func TestCreateWorklog(t *testing.T) {


### PR DESCRIPTION
# 073 config cleanup

Issue #73

## Fixed

As part of the wider #73 work, if the repository is switched, the configuration won't be able to be created.
Therefore to get around this, this PR is making (only for the configure command) a direct request to the repository to create the file.

As well as this the configure function is being removed as a requirement for the worklog service and worklog repository.

- Configure command goes directly to repository

---

This PR is part of the work required for #73.
The PR's have been broken down to make each of them fairly small and focused on a single element.

## Updated

These will be filled out as part of a future PR.

- [ ] Readme
- [ ] Version
