### PR TITLE
071 End date defaults far into future (again)

### DIFF
--- a/errors/exitCodes.go
+++ b/errors/exitCodes.go
@@ -1,7 +1,7 @@
 package errors
 
-// StartupErrors errors that have occured during the startup routine
+// StartupErrors errors that have occurred during the startup routine
 const StartupErrors = 1
 
-// RepoErrors errors that have occured from the repo layer
+// RepoErrors errors that have occurred from the repo layer
 const RepoErrors = 2

--- a/helpers/strings.go
+++ b/helpers/strings.go
@@ -13,7 +13,9 @@ const (
 	letterIdxMask    = 1<<letterIdxBits - 1
 )
 
-const RegexCaseInsesitive = "(?i)"
+// RegexCaseInsensitive regex to be prepended to not care about case
+// of characters
+const RegexCaseInsensitive = "(?i)"
 
 // RandAlphabeticString Generator function of a random series of characters
 // Uses a-zA-Z character set

--- a/repository/bboltRepo.go
+++ b/repository/bboltRepo.go
@@ -78,7 +78,7 @@ func (*bboltRepo) GetByID(ID string, filter *model.Work) (*model.Work, error) {
 	defer db.Close()
 
 	sel := q.And(
-		q.Re("ID", helpers.RegexCaseInsesitive+ID),
+		q.Re("ID", helpers.RegexCaseInsensitive+ID),
 		filterQuery(filter),
 	)
 	viewErr := db.Select(sel).OrderBy("Revision").Find(&foundWls)
@@ -115,9 +115,9 @@ func openReadOnly() (*storm.DB, error) {
 
 func filterQuery(f *model.Work) q.Matcher {
 	sel := q.And(
-		q.Re("Title", helpers.RegexCaseInsesitive+f.Title),
-		q.Re("Description", helpers.RegexCaseInsesitive+f.Description),
-		q.Re("Author", helpers.RegexCaseInsesitive+f.Author),
+		q.Re("Title", helpers.RegexCaseInsensitive+f.Title),
+		q.Re("Description", helpers.RegexCaseInsensitive+f.Description),
+		q.Re("Author", helpers.RegexCaseInsensitive+f.Author),
 	)
 	return sel
 }

--- a/repository/mockRepo.go
+++ b/repository/mockRepo.go
@@ -12,7 +12,7 @@ type MockRepo struct {
 	mock.Mock
 }
 
-// Configure WorklogRepository method for testing
+// SaveConfig WorklogRepository method for testing
 func (m *MockRepo) SaveConfig(cfg *model.Config) error {
 	args := m.Called(cfg)
 	return args.Error(0)

--- a/repository/repositories.go
+++ b/repository/repositories.go
@@ -15,6 +15,8 @@ type WorklogRepository interface {
 	GetByID(id string, filter *model.Work) (*model.Work, error)
 }
 
+// ConfigRepository defines what a configuration
+// store should be capable of doing
 type ConfigRepository interface {
 	SaveConfig(cfg *model.Config) error
 }

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -26,6 +26,8 @@ func NewYamlFileRepo() WorklogRepository {
 	return &yamlFileRepo{}
 }
 
+// NewYamlConfig Generator for configuration repository
+// in a yaml format
 func NewYamlConfig(dir string) ConfigRepository {
 	configDir = dir + string(filepath.Separator)
 	return &yamlFileRepo{}

--- a/repository/yamlFileRepo.go
+++ b/repository/yamlFileRepo.go
@@ -115,10 +115,6 @@ func (*yamlFileRepo) GetAllBetweenDates(startDate, endDate time.Time, filter *mo
 	var worklogs []*model.Work
 	var errors []string
 
-	if (endDate == time.Time{}) {
-		endDate = time.Date(3000, time.January, 1, 0, 0, 0, 0, time.Now().Location())
-	}
-
 	fileNames, err := getAllFileNamesBetweenDates(startDate, endDate)
 	if err != nil {
 		return worklogs, err

--- a/service/worklogService.go
+++ b/service/worklogService.go
@@ -51,6 +51,11 @@ func (s *service) EditWorklog(id string, newWl *model.Work) (int, error) {
 func (*service) GetWorklogsBetween(start, end time.Time, filter *model.Work) ([]*model.Work, int, error) {
 	var worklogs model.WorkList
 	var err error
+
+	if (end == time.Time{}) {
+		end = time.Date(3000, time.January, 1, 0, 0, 0, 0, time.Now().Location())
+	}
+
 	worklogs, err = repo.GetAllBetweenDates(start, end, filter)
 	if err != nil {
 		return worklogs, http.StatusInternalServerError, err


### PR DESCRIPTION
# End date defaults far into future (again)

Issue #71

## Fixed

- Moved the logic to change the end date if none provided out of the repo, and into the service. This ensures that it isn't forgotten when adding another repository.

## Updated

Readme doesn't need updating for this change, and version bumps aren't currently happening until #73 is completed.

- [ ] Readme
- [ ] Version
