### PR TITLE
100 - Prevent duplicate tags

### DIFF
--- a/helpers/strings.go
+++ b/helpers/strings.go
@@ -72,3 +72,17 @@ func AInB(a, b string) bool {
 		strings.ToLower(b),
 		strings.ToLower(a))
 }
+
+// DeduplicateString removes items when there is more than 1 of the same item
+// https://stackoverflow.com/a/66751055
+func DeduplicateString(s []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range s {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/helpers/strings_test.go
+++ b/helpers/strings_test.go
@@ -62,3 +62,46 @@ func TestRandHexadecimalStringRandomness(t *testing.T) {
 		seen = append(seen, str)
 	}
 }
+
+func TestDeduplicateString(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   []string
+		exp  []string
+	}{
+		{
+			name: "Empty",
+			in:   []string{},
+			exp:  []string{},
+		}, {
+			name: "1 item",
+			in:   []string{"a"},
+			exp:  []string{"a"},
+		}, {
+			name: "2 items",
+			in:   []string{"a", "b"},
+			exp:  []string{"a", "b"},
+		}, {
+			name: "1 item repeated",
+			in:   []string{"a", "a"},
+			exp:  []string{"a"},
+		}, {
+			name: "2 items repeated",
+			in:   []string{"a", "a", "b", "b"},
+			exp:  []string{"a", "b"},
+		}, {
+			name: "3 items, some repeated",
+			in:   []string{"a", "a", "b", "c", "b"},
+			exp:  []string{"a", "b", "c"},
+		},
+	}
+
+	for _, testItem := range tests {
+		t.Run(testItem.name, func(t *testing.T) {
+			assert.Equal(t, len(DeduplicateString(testItem.in)), len(testItem.exp))
+			for index, element := range DeduplicateString(testItem.in) {
+				assert.Equal(t, testItem.exp[index], element)
+			}
+		})
+	}
+}

--- a/helpers/version.go
+++ b/helpers/version.go
@@ -2,5 +2,5 @@ package helpers
 
 const (
 	// Version keep track of the version of the application
-	Version string = "0.6.2"
+	Version string = "0.6.3"
 )

--- a/service/worklogService.go
+++ b/service/worklogService.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/PossibleLlama/worklog/helpers"
 	"github.com/PossibleLlama/worklog/model"
 	"github.com/PossibleLlama/worklog/repository"
 )
@@ -22,6 +23,7 @@ func NewWorklogService(repository repository.WorklogRepository) WorklogService {
 }
 
 func (*service) CreateWorklog(wl *model.Work) (int, error) {
+	wl.Tags = helpers.DeduplicateString(wl.Tags)
 	if err := repo.Save(wl); err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -29,6 +31,7 @@ func (*service) CreateWorklog(wl *model.Work) (int, error) {
 }
 
 func (s *service) EditWorklog(id string, newWl *model.Work) (int, error) {
+	newWl.Tags = helpers.DeduplicateString(newWl.Tags)
 	wls, code, err := s.GetWorklogsByID(&model.Work{}, id)
 	if err != nil {
 		return code, err


### PR DESCRIPTION
# 100 - Prevent duplicate tags 

Issue #100

## Fixed

- Automatically deduplicates the provided tags from create and edit calls.

## Updated

- [x] Readme (none needed)
- [x] Version
