### PR TITLE
Add instruction to download goreleaser

### DIFF
--- a/.github/workflows/commit-main.yml
+++ b/.github/workflows/commit-main.yml
@@ -22,6 +22,9 @@ jobs:
 
     - name: Get dependencies
       run: make deps
+      
+    - name: Get goreleaser
+      run: go install github.com/goreleaser/goreleaser@latest
 
     - name: Generate binaries
       run: make compile


### PR DESCRIPTION
# GoReleaser patch

## Fixed

- When using goreleaser, download it first

## Updated

- [ ] Readme
- [ ] Version
