### PR TITLE
GoReleaser

### DIFF
--- a/.github/workflows/commit-main.yml
+++ b/.github/workflows/commit-main.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: worklog-binary
-        path: bin
+        path: dist
 
   run-ubuntu:
     name: Run-ubuntu

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-bin/*
+dist/*
 script*
-
-dist/


### PR DESCRIPTION
# GoRelease

## Fixed

- Use dist for a directory instead of bin

## Updated

- [ ] Readme
- [ ] Version
